### PR TITLE
Fix typos and atrocious spelling in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ to partition Scoobi code into separate logical entities - into separate classes 
 advantage of Scoobi is that its staging compiler works across library boundaries. Therefore
 you'll get the same Hadoop performance as if you had everything in the one file but with the
 productivity gains of having modular software;
-* **It's Scala**: Of course, with Scala you don't loose access to those precious Java libraries,
+* **It's Scala**: Of course, with Scala you don't lose access to those precious Java libraries,
 but you also get functional programming and concise syntax which makes writing Hadoop applications
 with Scoobi very productive ... and fun!
 
@@ -602,7 +602,3 @@ Contributions
 -------------
 Scoobi is released under the Apache license v2. We welcome contributions of bug fixes and/or new
 features via GitHib pull requests.
-
-
-
-


### PR DESCRIPTION
Hey ...  thanks for writing Scoobi!  It looks awesome.  However, my eyes started to hurt from all the spelling mistakes in the README.md file :), so I fixed it up, along with some other errors (e.g. you can't put dashes in Scala identifiers, and CSV was confused with CVS).
