### PR TITLE
Add seconds to the the working directory name

### DIFF
--- a/src/main/scala/com/nicta/scoobi/Scoobi.scala
+++ b/src/main/scala/com/nicta/scoobi/Scoobi.scala
@@ -62,7 +62,7 @@ object Scoobi {
   /* Timestamp used to mark each Scoobi working directory. */
   private val timestamp = {
     val now = new Date
-    val sdf = new SimpleDateFormat("yyyyMMddHHmm")
+    val sdf = new SimpleDateFormat("yyMMddHHmmss")
     sdf.format(now)
   }
 


### PR DESCRIPTION
If two separate Scoobi jobs are started within the same minute, it
fails because the directory exists. This happens quite often when
rerunning a short example, or rapidly switching projects.

Instead of the millennium and century being written, using the
current second seems more valuable.
