### PR TITLE
Small changes to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -587,7 +587,7 @@ Create a new Scoobi application and add some code:
     $ vi src/main/scala/MyApp.scala
 ```
 
-To use the sbt-scoobi plugin we need to include a `project/plugins/project/build.scala` file with the following contents:
+To use the sbt-scoobi plugin we need to include a `project/project/scoobi.scala` file with the following contents:
 
 ```scala
     import sbt._
@@ -608,7 +608,7 @@ And, we can add a pretty standard `build.sbt` that has a dependency on Scoobi:
 
     scalaVersion := "2.9.1"
 
-    libraryDependencies += "com.nicta" %% "scoobi" % "0.0.1" % "provided"
+    libraryDependencies += "com.nicta" %% "scoobi" % "0.2.0" % "provided"
 ```
 
 The `provided` is added to the `scoobi` dependency to let sbt know that Scoobi


### PR DESCRIPTION
Hi

When following the new README instructions on setting up the scoobi-sbt plugin, I got some deprecation warnings from sbt (0.11.1) that mentioned a new location for putting custom plugin code. I updated the README to reflect this.

I also changed the Scoobi version number in the example build.sbt file to 0.2.0, although it is still unclear to me how this is suposed to work without first building your own "publish-local" version of Scoobi since there doesn't seem to be a public ivy2/maven repository that is hosting Scoobi jar files. You might want to add a small explanation about that one too.
