### PR TITLE
Changed Filesystem.get calls to allow scoobi to run on the S3 filesystem implementation

### DIFF
--- a/src/main/scala/com/nicta/scoobi/DList.scala
+++ b/src/main/scala/com/nicta/scoobi/DList.scala
@@ -83,7 +83,7 @@ class DList[A : Manifest : WireFormat](private val ast: Smart.DList[A]) { self =
     new DObject[Iterable[A]] {
       def get: Iterable[A] = new Iterable[A] {
         def iterator = {
-          val fs = FileSystem.get(Scoobi.conf)
+          val fs = FileSystem.get(path.toUri, Scoobi.conf)
           val readers = fs.globStatus(new Path(path, "ch*")) map { (stat: FileStatus) =>
             new SequenceFile.Reader(fs, stat.getPath, Scoobi.conf)
           }

--- a/src/main/scala/com/nicta/scoobi/impl/exec/Executor.scala
+++ b/src/main/scala/com/nicta/scoobi/impl/exec/Executor.scala
@@ -54,7 +54,7 @@ object Executor {
 
     /* Check that all output dirs don't already exist. */
     def pathExists(p: Path) = {
-      val s = FileSystem.get(Scoobi.conf).globStatus(p)
+      val s = FileSystem.get(p.toUri, Scoobi.conf).globStatus(p)
       if (s == null)          false
       else if (s.length == 0) false
       else                    true

--- a/src/main/scala/com/nicta/scoobi/io/Helper.scala
+++ b/src/main/scala/com/nicta/scoobi/io/Helper.scala
@@ -26,7 +26,7 @@ import com.nicta.scoobi.Scoobi
 object Helper {
 
   /* Determine whether a path exists or not. */
-  def pathExists(p: Path): Boolean = ?(FileSystem.get(Scoobi.conf).globStatus(p)) match {
+  def pathExists(p: Path): Boolean = ?(FileSystem.get(p.toUri, Scoobi.conf).globStatus(new Path(p, "*"))) match {
     case None                     => false
     case Some(s) if s.length == 0 => false
     case Some(_)                  => true
@@ -34,7 +34,7 @@ object Helper {
 
   /** Determine the byte size of data specified by a path. */
   def pathSize(p: Path): Long = {
-    val fs = FileSystem.get(Scoobi.conf)
+    val fs = FileSystem.get(p.toUri, Scoobi.conf)
     fs.globStatus(p).map(stat => fs.getContentSummary(stat.getPath).getLength).sum
   }
 


### PR DESCRIPTION
Some minor changes, let me know if they're ok?

There are still places that FileSystem.get(conf) is called without a URI, but they seem to just be for temporary locations. Let me know if I need to also update those somehow.
