### PR TITLE
Supporting multiple output filesystems

### DIFF
--- a/src/main/scala/com/nicta/scoobi/Conf.scala
+++ b/src/main/scala/com/nicta/scoobi/Conf.scala
@@ -1,5 +1,6 @@
 package com.nicta.scoobi
 
+import java.net.URI
 import java.util.Date
 import java.text.SimpleDateFormat
 import org.apache.hadoop.fs.Path
@@ -75,9 +76,16 @@ trait ConfTrait {
     ?(conf.get("scoobi.jobid")).getOrElse(sys.error("Scoobi job id not set."))
 
   /** Get the Scoobi working directory. */
-  def getWorkingDirectory(conf: Configuration): Path = new Path(
+  def getWorkingDirectory(conf: Configuration, uri: Option[URI] = None): Path = new Path(
     (?(conf.get("scoobi.workdir")) match {
       case Some(s) => withTrailingSlash(s)
-      case None    => withTrailingSlash(FileSystem.get(conf).getHomeDirectory.toUri.toString) + ".scoobi-tmp/"
+      case None    => {
+        uri match {
+          case Some(uri) => withTrailingSlash(FileSystem.get(uri, conf).getHomeDirectory.toUri.toString) + ".scoobi-tmp/"
+          case _ => withTrailingSlash(FileSystem.get(conf).getHomeDirectory.toUri.toString) + ".scoobi-tmp/"
+        }
+        
+        
+      }
      }) + getJobId(conf))
 }

--- a/src/main/scala/com/nicta/scoobi/Scoobi.scala
+++ b/src/main/scala/com/nicta/scoobi/Scoobi.scala
@@ -15,6 +15,8 @@
   */
 package com.nicta.scoobi
 
+import org.apache.hadoop.conf.Configuration
+import java.net.URI
 /** Global Scoobi functions and values. */
 object Scoobi extends com.nicta.scoobi.WireFormatImplicits with com.nicta.scoobi.GroupingImplicits {
 
@@ -33,7 +35,7 @@ object Scoobi extends com.nicta.scoobi.WireFormatImplicits with com.nicta.scoobi
 
 
   /* Conf functions */
-  def getWorkingDirectory = Conf.getWorkingDirectory _
+  def getWorkingDirectory(conf: Configuration, uri: Option[URI] = None) = Conf.getWorkingDirectory(conf, uri)
   def conf = Conf.conf
   def jobId = Conf.jobId
   def getUserJars = Conf.getUserJars


### PR DESCRIPTION
Hey guys,

This change supports multiple output filesystems seamlessly without the need to override any properties.

However, I don't think my code does this in the right way at all, I'd really like some direction on how to do what I did properly.

Essentially all the change does is modify the getWorkingPath call to get a working directory for the correct output uri scheme, but I had to make a bunch of assumptions about where to get the output path from, and I don't think I did that correctly.

Some questions:
- I don't like how I get the output path (and check the filesystem), is there a way to get a single output path from somewhere?
  - I had to map through reducers/sinks to get (multiple?) output paths instead.
- given that there can be multiple outputs, why does scoobi store all results in a single tmp-out directory; shouldn't there be a temp output path per reducer given that there is an output path per reducer?
- I had to hack up the Conf.getWorkingDirectory to accept a uri, this also seems hacky, as there are still other calls to this method that don't get a properly scoped uri, so maybe they will break the feature in certain edge-cases?
- I'd prefer to set some sort of global uri scheme, but I didn't know the best place to do that.

(this includes the contents of the other pull request, but please feel free to ignore those minor changes)
