### PR TITLE
Fixed issue with hidden files getting checked in sequence/avro data sources

### DIFF
--- a/src/test/scala/com/nicta/scoobi/io/HelperSpec.scala
+++ b/src/test/scala/com/nicta/scoobi/io/HelperSpec.scala
@@ -76,6 +76,14 @@ class HelperSpec extends UnitSpecification {
                      createFileStatus("/base/c"))
     Helper.getSingleFilePerDir(input) must_== Set(new Path("/base/a/file1"), new Path("/base/b/file1"))
   }
+
+  "Get non hidden files" in new CommonFS {
+    val path = createSpecBasePath("hidden_files")
+    val partFilePath = new Path(path, "part-m-00000")
+    createEmptyFiles(new Path(path, "_SUCCESS"), new Path(path, ".hidden"), partFilePath)
+
+    Helper.getSingleFilePerDir(path) must_== Set(partFilePath.getPath)
+  }
 }
 
 trait CommonFS extends After {
@@ -96,7 +104,7 @@ trait CommonFS extends After {
     specPath.get
   }
 
-  def createFileStatus(path: String, isDir: Boolean = true): FileStatus = new FileStatus(0,isDir,0,0,0,new Path(path))
+  def createFileStatus(path: String, isDir: Boolean = true): FileStatus = new FileStatus(1,isDir,0,0,0,new Path(path))
 
   // delete the paths after the test has finished
   def after = specPath match {


### PR DESCRIPTION
- Added new optional PathFilter argument to Helper.getFileStatus and
  Helper.pathExists. Default behaviour is to ignore hidden files, ie.
  those that start with "." or "_".
- Added test case to verify the default filtering works.
