### PR TITLE
ScoobiApp.run should have parenthesis …

### DIFF
--- a/src/main/scala/com/nicta/scoobi/application/ScoobiApp.scala
+++ b/src/main/scala/com/nicta/scoobi/application/ScoobiApp.scala
@@ -23,7 +23,7 @@ trait ScoobiApp extends ScoobiCommandLineArgs with ScoobiAppConfiguration with H
   def args = userArguments
 
   /** this method needs to be overridden and define the code to be executed */
-  def run
+  def run()
 
   /**
    * parse the command-line argument and:


### PR DESCRIPTION
Add parenthesis, to avoid errors about side-effecting nullary methods being discouraged
