### PR TITLE
Issue #104: throwing a more descriptive error message when the reduce operation is called on an empty DList        

### DIFF
--- a/src/main/scala/com/nicta/scoobi/core/DList.scala
+++ b/src/main/scala/com/nicta/scoobi/core/DList.scala
@@ -213,7 +213,10 @@ trait DList[A] {
     /* Group all elements together (so they go to the same reducer task) and then
      * combine them. */
     val x: DObject[Iterable[A]] = imc.groupBy(_ => 0).combine(op).map(_._2).materialize
-    x.map(_.head)
+    x map {
+      case it if it.isEmpty => sys.error("the reduce operation is called on an empty list")
+      case it               => it.head
+    }
   }
 
   /**Multiply up the elements of this distribute list. */

--- a/src/test/scala/com/nicta/scoobi/core/DListSpec.scala
+++ b/src/test/scala/com/nicta/scoobi/core/DListSpec.scala
@@ -6,9 +6,15 @@ import Scoobi._
 import testing.NictaSimpleJobs
 
 class DListSpec extends NictaSimpleJobs {
+
   tag("issue 99")
   "a DList can be created and persisted with some Text" >> { implicit sc: SC =>
     val list = DList((new Text("key1"), new Text("value1")), (new Text("key2"), new Text("value2")))
     run(list).sorted must_== Seq("(key1,value1)", "(key2,value2)")
+  }
+
+  tag("issue 104")
+  "Summing up an empty list should do something graceful" >> { implicit c: SC =>
+    persist(DList[Int]().sum) must throwAn[Exception](message = "the reduce operation is called on an empty list")
   }
 }


### PR DESCRIPTION
Throwing a more descriptive error message when the reduce operation is called on an empty DList

Fixes #104
