### PR TITLE
Add ability to set the input size threshold per reducer (Issue #129)

### DIFF
--- a/src/main/scala/com/nicta/scoobi/application/ScoobiConfiguration.scala
+++ b/src/main/scala/com/nicta/scoobi/application/ScoobiConfiguration.scala
@@ -126,6 +126,14 @@ case class ScoobiConfiguration(configuration: Configuration = new Configuration,
   /** Get the min number of reducers to use in M/R jobs */
   def getMinReducers = configuration.getInt("scoobi.mapreduce.reducers.min", 1)
 
+  /** Set the input size threshold in GB for each reducer */
+  def setReducerInputSizeThreshold(sizeInGB: Float) {
+    configuration.setFloat("scoobi.mapreduce.reducers.inputsize.threshold", sizeInGB)
+  }
+
+  /** Get the input size threshold in GB for each reducer */
+  def getReducerInputSizeThreshold = configuration.getFloat("scoobi.mapreduce.reducers.inputsize.threshold", 1.0f)
+
   /**
    * set a new job name to help recognize the job better
    */

--- a/src/main/scala/com/nicta/scoobi/impl/exec/MapReduceJob.scala
+++ b/src/main/scala/com/nicta/scoobi/impl/exec/MapReduceJob.scala
@@ -198,7 +198,7 @@ class MapReduceJob(stepId: Int) {
      * estimate the size of output data to be the size of the input data to the MapReduce job. Then, set
      * the number of reduce tasks to the number of 1GB data chunks in the estimated output. */
     val inputBytes: Long = mappers.keys.map(_.inputSize).sum
-    val inputGigabytes: Int = (inputBytes / (1000 * 1000 * 1000)).toInt + 1
+    val inputGigabytes: Int = (inputBytes / (configuration.getReducerInputSizeThreshold * 1000 * 1000 * 1000)).toInt + 1
     val numReducers: Int = inputGigabytes.toInt.max(configuration.getMinReducers).min(configuration.getMaxReducers)
     job.setNumReduceTasks(numReducers)
 


### PR DESCRIPTION
- Added a new configuration option to set the input size threshold in GB
  for each reducer. Default is 1.
