### PR TITLE
Fixed StackOverflowError with groupBy and DObject joining (Issue #127)

### DIFF
--- a/src/main/scala/com/nicta/scoobi/impl/plan/Intermediate.scala
+++ b/src/main/scala/com/nicta/scoobi/impl/plan/Intermediate.scala
@@ -481,7 +481,7 @@ object Intermediate {
       val gbkMSCRs = relatedNodes(g) map { related =>
 
         /* Create a GbkOutputChannel for each GroupByKey and the related group. */
-        val gbkOCs = related.gbks map { outputChannelForGbk(_, g) }
+        val gbkOCs = related.gbks map { outputChannelForGbk(_, g, related) }
 
         /* Create a MapperInputChannel for each group of ParallelDo nodes, "belonging" to this
          * set of related GBKs, that share the same input. */
@@ -685,7 +685,7 @@ object Intermediate {
      *    another MSCR (in a MapperInputChannel)
      *
      * (Note: Perhaps this condition is too restrictive!) */
-    private def outputChannelForGbk(gbk: DComp[_, _ <: Shape], g: DGraph): GbkOutputChannel = {
+    private def outputChannelForGbk(gbk: DComp[_, _ <: Shape], g: DGraph, related: MSCRGraph.Relation): GbkOutputChannel = {
 
       def getSingleSucc(d: DComp[_, _ <: Shape]): Option[DComp[_, _ <: Shape]] =
         g.succs.get(d) match {
@@ -702,17 +702,27 @@ object Intermediate {
         maybeOC.getOrElse(oc)
       }
 
+      /** Follow predecessors up the graph finding any related GroupByKey nodes after any Materialize nodes */
+      def hasMaterializedPredWithRelatedPreds(node: DComp[_, _ <: Shape], foundMaterialize: Boolean = false): Boolean = {
+        g.preds.get(node).map(_.exists(_ match {
+          case a if(isGroupByKey(a))  => (foundMaterialize && related.gbks.contains(a))
+          case a if(isMaterialize(a)) => hasMaterializedPredWithRelatedPreds(a, true)
+          case a                      => hasMaterializedPredWithRelatedPreds(a, foundMaterialize)
+        })).getOrElse(false)
+      }
+
       def addCombinerAndOrReducer(oc: GbkOutputChannel): GbkOutputChannel = {
         def addTheReducer(d: DComp[_, _ <: Shape], oc: GbkOutputChannel): GbkOutputChannel = {
           val maybeOC =
             for { d_                      <- getSingleSucc(d)
                   reducer                 <- getParallelDo(d_)
                   hasNoSuccessors         <- Some(!g.succs.get(reducer).isDefined)
+                  hasDepPredecssors       <- Some(hasMaterializedPredWithRelatedPreds(reducer))
                   hasMaterializeSucessor  <- Some(g.succs.get(reducer).map(_.exists(isMaterialize(_))).getOrElse(false))
                   hasGroupBarrier         <- Some(reducer.groupBarrier)
                   hasFuseBarrier          <- Some(reducer.fuseBarrier)
 
-            } yield (if (hasNoSuccessors || hasMaterializeSucessor || hasGroupBarrier || hasFuseBarrier) { oc.addReducer(reducer)} else { oc })
+            } yield (if ((hasNoSuccessors || hasMaterializeSucessor || hasGroupBarrier || hasFuseBarrier) && !hasDepPredecssors) { oc.addReducer(reducer) } else { oc })
           maybeOC.getOrElse(oc)
         }
 

--- a/src/test/scala/com/nicta/scoobi/acceptance/MultipleMscrSpec.scala
+++ b/src/test/scala/com/nicta/scoobi/acceptance/MultipleMscrSpec.scala
@@ -52,4 +52,22 @@ class MultipleMscrSpec extends NictaSimpleJobs {
      * be implemented by a separate MSCR.*/
     (unique(input1) join unique(input2)).run must_== Seq(("hello", ("hello", "hello")))
   }
+
+  "A DList grouped in two different ways with one of them materialized and then joined to the other should work." >> { implicit c: SC =>
+
+    val input = fromDelimitedInput("k1,v1","k2,v2").collect { case key :: value :: _ => (key, value) }
+
+    val inputGrouped = input.groupBy(_._1)
+    val inputGroupedDifferently = input.groupBy(_._2)
+
+    val inputGroupedAsDObject = inputGrouped.materialize
+
+    val dObjectJoinedToInputGroupedDiff = (inputGroupedAsDObject join inputGroupedDifferently)
+
+    val expectedGBKs = Seq(("k1",Seq(("k1","v1"))), ("k2",Seq(("k2","v2"))))
+
+    persist(dObjectJoinedToInputGroupedDiff.materialize).toSeq must_== Seq(
+        (expectedGBKs, ("v1",Seq(("k1","v1")))),
+        (expectedGBKs, ("v2",Seq(("k2","v2")))))
+  }
 }


### PR DESCRIPTION
Added check in outputChannelForGbk on Materialize predesessors to make
sure there are no related GBK nodes.
