### PR TITLE
Use XStream in a fashion that doesn't require its dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,7 @@ libraryDependencies ++= Seq(
   "org.apache.avro" % "avro" % "1.7.0",
   "org.apache.hadoop" % "hadoop-client" % "2.0.0-mr1-cdh4.0.0",
   "org.apache.hadoop" % "hadoop-core" % "2.0.0-mr1-cdh4.0.0",
-  "com.thoughtworks.xstream" % "xstream" % "1.4.3",
+  "com.thoughtworks.xstream" % "xstream" % "1.4.3" intransitive(),
   "org.scalaz" %% "scalaz-core" % "6.95",
   "org.specs2" %% "specs2" % "1.12" % "optional",
   "org.specs2" % "classycle" % "1.4.1"% "test",

--- a/src/main/scala/com/nicta/scoobi/impl/exec/DistCache.scala
+++ b/src/main/scala/com/nicta/scoobi/impl/exec/DistCache.scala
@@ -21,6 +21,7 @@ import org.apache.hadoop.fs._
 import org.apache.hadoop.filecache._
 import org.apache.hadoop.conf.Configuration
 import com.thoughtworks.xstream.XStream
+import com.thoughtworks.xstream.io.xml.StaxDriver
 import Configurations._
 
 /** Faciliate making an object available to all tasks (mappers, reducers, etc). Use
@@ -28,7 +29,7 @@ import Configurations._
   * distributed cache. Two APIs are provided for pushing and pulling objects. */
 object DistCache {
 
-  private val xstream = new XStream()
+  private val xstream = new XStream(new StaxDriver())
 
   /** Make a local filesystem path based on a 'tag' to temporarily store the
     * serialized object. */


### PR DESCRIPTION
Should make everyone happy. Easier for sbt assembly (don't need to resolve the conflicting dependencies xstream has). Means 1 less required jar for sbt-assembly to package. And 2 less jars for the libjars. This driver uses the Java's StAX, which is streaming based and apparently pretty fast :D 
