### PR TITLE
Fix bug in 'GBK relatedness' algorithm.

### DIFF
--- a/src/main/scala/com/nicta/scoobi/impl/plan/Smart.scala
+++ b/src/main/scala/com/nicta/scoobi/impl/plan/Smart.scala
@@ -42,8 +42,14 @@ object Smart {
   sealed abstract class DComp[A : Manifest : WireFormat, Sh <: Shape] {
 
     val id = Id.get
-    /* We don't want structural equality */
-    override def equals(arg0: Any): Boolean = eq(arg0.asInstanceOf[AnyRef])
+
+    override def equals(other: Any) = {
+      other match {
+        case dc: DComp[_, _] => dc.id == this.id
+        case _               => false
+      }
+    }
+
     override def hashCode = id
 
     def toVerboseString: String


### PR DESCRIPTION
The 'GBK relatedness' algorithm is responsible for traversing the
computation graph and identifying clusters of GBK nodes that are
"related" and can therefore be exectued as part of the same MapReduce
job (i.e. same MSCR). Fix bugs in the algorithm where it is being to
greedy in its determination of whether two GBKs are related.
Specifically:
- Relatedness via shared ParallelDo inputs should only include Arr-shaped
  nodes, not Exp-shaped nodes;
- Check for indirect GBK dependencies through existing related GBK
  clusters.

Add Specs that exercise the bugs.
