### PR TITLE
Quick start bug fixes (and consistently use CDH3).

### DIFF
--- a/guide/Quick Start.html
+++ b/guide/Quick Start.html
@@ -83,7 +83,9 @@ libraryDependencies += &quot;com.nicta&quot; %% &quot;scoobi&quot; % &quot;0.5.0
 
 scalacOptions ++= Seq(&quot;-Ydependent-method-types&quot;, &quot;-deprecation&quot;)
 
-resolvers += &quot;Sonatype-snapshots&quot; at &quot;http://oss.sonatype.org/content/repositories/snapshots&quot;
+resolvers += &quot;Cloudera Maven Repository&quot; at &quot;https://repository.cloudera.com/content/repositories/releases/&quot;
+
+resolvers += &quot;Scoobi Releases&quot; at &quot;http://nicta.github.com/scoobi/releases/&quot;
 </code></pre><a name="Write+your+code"><h3>Write your code</h3></a><p>Now we can write some code. In <code class="prettyprint">src/main/scala/myfile.scala</code>, for instance:</p>
 <pre><code class="prettyprint">package mypackage.myapp
 
@@ -103,7 +105,7 @@ object WordCount extends ScoobiApp {
 }
 </code></pre><a name="Running"><h3>Running</h3></a><p>The Scoobi application can now be compiled and run using sbt:</p>
 <pre><code class="prettyprint">&gt; sbt compile
-&gt; sbt run-main mypackage.myapp.WordCount input-files output
+&gt; sbt 'run-main mypackage.myapp.WordCount input-files output'
 </code></pre><p>Your Hadoop configuration will automatically get picked up, and all relevant JARs will be made available.</p><p>If you had any trouble following along, take a look at <a href="https://github.com/NICTA/scoobi/tree/SCOOBI-0.5.0-cdh4/examples/wordCount">Word Count</a> for a self contained example.</p></div></status></div></div>
                        <div class="col2"><div id="leftcolumn"><div id="tree">
       <ul><li id="1571098801"><a href="../guide/User Guide.html#User+Guide">User Guide</a>


### PR DESCRIPTION
The quick start did not work for me.  I didn't need the Sonatype snapshot repository but I needed the Cloudera repository.  Also, for some reason, I needed the Scoobi releases repository.  When I go to that URL I get a 404, but without it sbt doesn't find a custom version of scalaz (6.95) that is required.  

The quickstart also starts out talking about CHD3 but the example uses CHD4.

Also, run-main needs to be in quotes.
