### PR TITLE
Add logging when move the temporary path to the real output path

### DIFF
--- a/src/main/scala/com/nicta/scoobi/impl/exec/MapReduceJob.scala
+++ b/src/main/scala/com/nicta/scoobi/impl/exec/MapReduceJob.scala
@@ -273,6 +273,7 @@ class MapReduceJob(stepId: Int) {
           fs.mkdirs(outDir)
           val files = outputFiles filter isResultFile(reducer.tag, ix)
           files foreach moveTo(outDir)
+          logger.info("Save output of job to '"+outDir.toString()+"'")
         }
       }
     }


### PR DESCRIPTION
Currently, the log only tell the user that the output of job is stored in a temporary folder. This is not so clear and a little confusing for users. The purpose of this enhancement is adding another logging that tell the user the result is stored into the folder which user specify. 

[INFO] FileOutputCommitter - Saved output of task 'attempt_local_0001_r_000000_0' to /tmp/scoobi-jianfezhang/scoobi-20121214-090330-ScoobiExample$-ad7a2d99-88d5-4af0-9e67-26406776ba53/tmp-out                            // origin logging

[INFO] Step - Save output of job to 'data/output'                    // what I add
