### PR TITLE
Be on the correct Filesystem for output to S3.

### DIFF
--- a/src/main/scala/com/nicta/scoobi/impl/exec/MapReduceJob.scala
+++ b/src/main/scala/com/nicta/scoobi/impl/exec/MapReduceJob.scala
@@ -270,7 +270,7 @@ class MapReduceJob(stepId: Int) {
     reducers.foreach { case (sinks, (_, reducer)) =>
       sinks.zipWithIndex.foreach { case (sink, ix) =>
         sink.outputPath foreach { outDir =>
-          fs.mkdirs(outDir)
+          FileSystem.get(outDir.toUri, configuration).mkdirs(outDir)
           val files = outputFiles filter isResultFile(reducer.tag, ix)
           files foreach moveTo(outDir)
           logger.info("Save output of job to: "+outDir)


### PR DESCRIPTION
#169 change to move rather than copy to output breaks Scoobi on AWS

Elastic MapReduce for a standard usecase where HDFS is the temporary
filesystem and output to S3.

Making the output directories on the right FileSystem in `MapReduceJob`
is a fix. The foreign test in `FileSystems.moveTo` covers matters until
#76 is addressed.
