### PR TITLE
Be on the correct Filesystem for output to S3. (0.7.0 version)

### DIFF
--- a/src/main/scala/com/nicta/scoobi/impl/io/FileSystems.scala
+++ b/src/main/scala/com/nicta/scoobi/impl/io/FileSystems.scala
@@ -87,14 +87,24 @@ trait FileSystems {
   /**
    * create a directory if it doesn't exist already
    */
-  def mkdir(dest: String)(implicit configuration: ScoobiConfiguration) {
+  def mkdir(dest: Path)(implicit sc: ScoobiConfiguration) {
     if (!exists(dest))
-      fileSystem.mkdirs(new Path(dest))
+      FileSystem.get(dest.toUri, sc.configuration).mkdirs(dest)
   }
 
+  /**
+   * create a directory if it doesn't exist already
+   */
+  def mkdir(dest: String)(implicit sc: ScoobiConfiguration) {
+    mkdir(new Path(dest))
+  }
+
+  def exists(path: Path)(implicit sc: ScoobiConfiguration): Boolean =
+    FileSystem.get(path.toUri, sc.configuration).exists(path)
+
   /** @return true if a Path exists with this name on the file system */
-  def exists(path: String)(implicit configuration: ScoobiConfiguration) =
-    fileSystem.exists(new Path(path))
+  def exists(path: String)(implicit configuration: ScoobiConfiguration): Boolean =
+    exists(new Path(path))
 
   /**
    * delete all the files in a given directory on the file system

--- a/src/main/scala/com/nicta/scoobi/impl/plan/mscr/OutputChannel.scala
+++ b/src/main/scala/com/nicta/scoobi/impl/plan/mscr/OutputChannel.scala
@@ -91,7 +91,7 @@ trait MscrOutputChannel extends OutputChannel { outer =>
     // copy the each result file to its sink
     sinks.foreach { sink =>
       sink.outputPath foreach { outDir =>
-        fs.mkdirs(outDir)
+        mkdir(outDir)
         outer.logger.debug("creating directory "+outDir)
 
         val outputs = outputFiles.filter(isResultFile(tag, sink.id))
@@ -102,7 +102,7 @@ trait MscrOutputChannel extends OutputChannel { outer =>
     // copy the success file to every output directory
     outputFiles.find(_.getName ==  "_SUCCESS").foreach { successFile =>
       sinks.flatMap(_.outputPath).foreach { outDir =>
-        fs.mkdirs(outDir)
+        mkdir(outDir)
         copyTo(outDir)(configuration)(successFile)
       }
     }


### PR DESCRIPTION
c.f. #185. New `MscrOutputChannel.collectOutputs` has slipped in `fs.mkdirs(...)`
instead of `FileSystem.get(...).mkdirs(...)`.

Most of the fix is in `FileSystems` for wider application.

```
You possibly called FileSystem.get(conf) when you should have called FileSystem.get(uri, conf) to obtain a file system supporting your path.
    at org.apache.hadoop.fs.FileSystem.checkPath(FileSystem.java:384)
    at org.apache.hadoop.hdfs.DistributedFileSystem.getPathName(DistributedFileSystem.java:129)
    at org.apache.hadoop.hdfs.DistributedFileSystem.mkdirs(DistributedFileSystem.java:321)
    at org.apache.hadoop.fs.FileSystem.mkdirs(FileSystem.java:1128)
    at com.nicta.scoobi.impl.plan.mscr.MscrOutputChannel$$anonfun$collectOutputs$1$$anonfun$apply$1.apply(OutputChannel.scala:94)
    at com.nicta.scoobi.impl.plan.mscr.MscrOutputChannel$$anonfun$collectOutputs$1$$anonfun$apply$1.apply(OutputChannel.scala:93)
  at scala.Option.foreach(Option.scala:197)
...
```
