### PR TITLE
Deprecate BasicDoFn

### DIFF
--- a/src/main/scala/com/nicta/scoobi/Scoobi.scala
+++ b/src/main/scala/com/nicta/scoobi/Scoobi.scala
@@ -41,6 +41,7 @@ object Scoobi extends core.WireFormatImplicits
   type DObject[A] = com.nicta.scoobi.core.DObject[A]
 
   type DoFn[A, B] = com.nicta.scoobi.core.DoFn[A, B]
+  @deprecated("DoFn is a drop in replacement", "0.7")
   type BasicDoFn[A, B] = com.nicta.scoobi.core.BasicDoFn[A, B]
   type EnvDoFn[A, B, E] = com.nicta.scoobi.core.EnvDoFn[A, B, E]
 

--- a/src/main/scala/com/nicta/scoobi/core/EnvDoFn.scala
+++ b/src/main/scala/com/nicta/scoobi/core/EnvDoFn.scala
@@ -47,9 +47,9 @@ trait EnvDoFn[A, B, E] extends DoFunction { outer =>
  * environment
  */
 trait DoFn[A, B] extends EnvDoFn[A, B, Unit] {
-  def setup()
+  def setup() {}
   def process(input: A, emitter: Emitter[B])
-  def cleanup(emitter: Emitter[B])
+  def cleanup(emitter: Emitter[B]) {}
 
   final def setup(env: Unit) { setup() }
   final def process(env: Unit, input: A, emitter: Emitter[B]) { process(input, emitter) }
@@ -63,14 +63,8 @@ trait Emitter[A] extends EmitterWriter {
   def emit(value: A)
 }
 
-/**
- * Interface for specifying parallel operation over DLists in the absence of an
- * environment with an do-nothing setup and cleanup phases
- */
-trait BasicDoFn[A, B] extends DoFn[A, B] {
-  def setup() {}
-  def cleanup(emitter: Emitter[B]) {}
-}
+@deprecated("DoFn is a drop-in replacement", "0.7")
+trait BasicDoFn[A, B] extends DoFn[A, B]
 
 /**
  * Internal version of a EnvDoFn functions without type information

--- a/src/main/scala/com/nicta/scoobi/lib/Matrix.scala
+++ b/src/main/scala/com/nicta/scoobi/lib/Matrix.scala
@@ -245,7 +245,7 @@ object LinearAlgebra {
       val left = matrix.by(_._1._2)
 
       left.groupByKey.parallelDo(
-        new BasicDoFn[(Elem, Iterable[((Elem, Elem), Value)]), ((Elem, Elem), Q)] {
+        new DoFn[(Elem, Iterable[((Elem, Elem), Value)]), ((Elem, Elem), Q)] {
           def process(input: (Elem, Iterable[((Elem, Elem), Value)]), emitter: Emitter[((Elem, Elem), Q)]) = {
             val bs = generateRow()
 
@@ -267,7 +267,7 @@ object LinearAlgebra {
       val left = matrix.map(a => (a._1._2, (a._1._1,a._2)))
 
       left.groupByKey.parallelDo(
-        new BasicDoFn[(Int, Iterable[(Int, Value)]), ((Int, Int), Q)] {
+        new DoFn[(Int, Iterable[(Int, Value)]), ((Int, Int), Q)] {
           def process(input: (Int, Iterable[(Int, Value)]), emitter: Emitter[((Int, Int), Q)]) = {
             val bs = generateRow()
 
@@ -290,7 +290,7 @@ object LinearAlgebra {
       val right = r.by(_._1._1).map(x => (x._1, Right(x._2): Either[((Elem, Elem), Value), ((Elem, Elem), V)]))
 
       (left ++ right).groupByKey.parallelDo(
-        new BasicDoFn[(Elem, Iterable[Either[((Elem, Elem), Value), ((Elem, Elem), V)]]), ((Elem, Elem), Q)] {
+        new DoFn[(Elem, Iterable[Either[((Elem, Elem), Value), ((Elem, Elem), V)]]), ((Elem, Elem), Q)] {
           def process(input: (Elem, Iterable[Either[((Elem, Elem), Value), ((Elem, Elem), V)]]), emitter: Emitter[((Elem, Elem), Q)]) = {
             val as: ArrayBuffer[((Elem, Elem), Value)] = new ArrayBuffer[((Elem, Elem), Value)]()
             val bs: ArrayBuffer[((Elem, Elem), V)] = new ArrayBuffer[((Elem, Elem), V)]()

--- a/src/main/scala/com/nicta/scoobi/lib/Relational.scala
+++ b/src/main/scala/com/nicta/scoobi/lib/Relational.scala
@@ -165,7 +165,7 @@ object Relational {
     }
   }
 
-  private def innerJoin[T, A, B] = new BasicDoFn[((T, Boolean), Iterable[Either[A, B]]), (T, (A, B))] {
+  private def innerJoin[T, A, B] = new DoFn[((T, Boolean), Iterable[Either[A, B]]), (T, (A, B))] {
     def process(input: ((T, Boolean), Iterable[Either[A, B]]), emitter: Emitter[(T, (A, B))]) {
       var alist = new ArrayBuffer[A]
 
@@ -178,7 +178,7 @@ object Relational {
     }
   }
 
-  private def rightOuterJoin[T, A, B] = new BasicDoFn[((T, Boolean), Iterable[Either[A, B]]), (T, (Option[A], B))] {
+  private def rightOuterJoin[T, A, B] = new DoFn[((T, Boolean), Iterable[Either[A, B]]), (T, (Option[A], B))] {
     def process(input: ((T, Boolean), Iterable[Either[A, B]]), emitter: Emitter[(T, (Option[A], B))]) {
       var alist = new ArrayBuffer[A]
 
@@ -199,7 +199,7 @@ object Relational {
   private def fullOuterJoin[T, A, B, V](
     hasLeft: (T, A) => V,
     hasRight: (T, B) => V,
-    hasBoth: (T, A, B) => V): BasicDoFn[((T, Boolean), Iterable[Either[A, B]]), (T, V)] = new BasicDoFn[((T, Boolean), Iterable[Either[A, B]]), (T, V)] {
+    hasBoth: (T, A, B) => V): DoFn[((T, Boolean), Iterable[Either[A, B]]), (T, V)] = new DoFn[((T, Boolean), Iterable[Either[A, B]]), (T, V)] {
     def process(input: ((T, Boolean), Iterable[Either[A, B]]), emitter: Emitter[(T, V)]) {
       val alist = new ArrayBuffer[A]
       var bseen = false
@@ -233,7 +233,7 @@ object Relational {
                        B : WireFormat,
                        V : WireFormat](
     d1: DList[(K, A)],
-    d2: DList[(K, B)])(dofn: BasicDoFn[((K, Boolean), Iterable[Either[A, B]]), (K, V)]): DList[(K, V)] = {
+    d2: DList[(K, B)])(dofn: DoFn[((K, Boolean), Iterable[Either[A, B]]), (K, V)]): DList[(K, V)] = {
 
     /* Map left and right DLists to be of the same type. Label the left as 'true' and the
      * right as 'false'. Note the hack cause DList doesn't yet have the co/contravariance. */
@@ -282,12 +282,10 @@ object Relational {
      * restarted; otherwise you may lose records unknowingly. */
     def addRandIntToKey[A, B](ub: Int, seed: Int) = new DoFn[(A, B), ((A, Int), B)] {
       val rgen = new util.Random(seed)
-      def setup() {}
       def process(input: (A, B), emitter: Emitter[((A, Int), B)]) {
         val (a,b) = input
         emitter.emit(((a, rgen.nextInt(ub)), b))
       }
-      def cleanup(emitter: Emitter[((A, Int), B)]) {}
     }
 
     import scalaz._, Scalaz._

--- a/src/test/scala/com/nicta/scoobi/acceptance/PersistSpec.scala
+++ b/src/test/scala/com/nicta/scoobi/acceptance/PersistSpec.scala
@@ -70,7 +70,7 @@ class PersistSpec extends NictaSimpleJobs with ResultFiles {
       val l2 = l1.map(_ + 1)
 
       var processedNumber = 0
-      val doFn = new BasicDoFn[Int, Int] {
+      val doFn = new DoFn[Int, Int] {
         def process(input: Int, emitter: Emitter[Int]) {
           processedNumber += 1
           if (processedNumber > 3) failure("too many computations")


### PR DESCRIPTION
I was going to ask on the mailing list, but probably easier to do as an issue with a patch. Is there any reason we have BasicDoFn?

(Note, this introduces a very minor source break, where 'override' becomes required on DoFn on setup / cleanup )
