### PR TITLE
set libjardir in command line rather than system property

### DIFF
--- a/src/main/scala/com/nicta/scoobi/application/LibJars.scala
+++ b/src/main/scala/com/nicta/scoobi/application/LibJars.scala
@@ -40,7 +40,7 @@ trait LibJars {
   /**
    * @return the path of the directory to use when loading jars to the filesystem.
    */
-  def libjarsDirectory = fss.dirPath(sysProps.get("scoobi.libjarsdir").getOrElse("libjars"))
+  def libjarsDirectory(implicit configuration: ScoobiConfiguration) = fss.dirPath(configuration.get("scoobi.libjarsdir","libjars"))
 
   /** this variable controls if the upload must be done at all */
   def upload: Boolean = true


### PR DESCRIPTION
Currently, the libjarsdir is able to been set in System property. You either have to set system property in hadoop-env or in the code at the beginning of your code. 
This patch is to set the libjarsdir in the command line rather than system property. Because jar will conflit if you use different versions of jars in your job, this often happens when you have production job running and also you are developing new jobs. By setting libjardirs in the command line can enable user to use different versions of jars.

BTW, I notice the scoobi-0.7.0 only support cdh4. And my environment is cdh3, so I make this patch in the cdh3 branch.
