### PR TITLE
implicit SeqSchema for anything with a WireFormat

### DIFF
--- a/src/main/scala/com/nicta/scoobi/io/sequence/SeqSchema.scala
+++ b/src/main/scala/com/nicta/scoobi/io/sequence/SeqSchema.scala
@@ -29,6 +29,9 @@ import org.apache.hadoop.io.BytesWritable
 import scala.collection.generic.CanBuildFrom
 import scala.collection.mutable.Builder
 
+import java.io._
+import collection.mutable
+import com.nicta.scoobi.core.WireFormat
 
 /** Type class for conversions between basic Scala types and Hadoop Writable types. */
 trait SeqSchema[A] {
@@ -101,4 +104,26 @@ object SeqSchema {
     }
     val mf: Manifest[SeqType] = implicitly
   }
+
+  implicit def anyWFSeqSchema[A : WireFormat]: SeqSchema[A] = new SeqSchema[A] {
+    type SeqType = BytesWritable
+
+    val b = mutable.ArrayBuffer[Byte]().mapResult(_.toArray)
+
+    def toWritable(a: A) = {
+      val bs = new ByteArrayOutputStream
+      implicitly[WireFormat[A]].toWire(a, new DataOutputStream(bs))
+      new BytesWritable(bs.toByteArray)
+    }
+    def fromWritable(xs: BytesWritable): A = {
+      b.clear()
+      xs.getBytes.take(xs.getLength).foreach { x => b += x }
+      val bArr = b.result()
+
+      val bais = new ByteArrayInputStream(bArr)
+      implicitly[WireFormat[A]].fromWire(new DataInputStream(bais))
+    }
+    val mf: Manifest[SeqType] = implicitly
+  }
+
 }


### PR DESCRIPTION
I added an implicit SeqSchema for anything that has a WireFormat.  It was a bit of a hassle to persist anything as a sequence file that wasn't one of the standard types.  Also,  I wanted to use it for checkpointing and writing the avro schema for each checkpoint is a bit prohibitive - of course, this may change when/if the plugin is updated for scala 2.10.

Is there a better way to support this?
