### PR TITLE
#239: FileUtil.copy in mixed S3/HDFS.

### DIFF
--- a/src/main/scala/com/nicta/scoobi/impl/io/FileSystems.scala
+++ b/src/main/scala/com/nicta/scoobi/impl/io/FileSystems.scala
@@ -145,7 +145,7 @@ trait FileSystems {
 
   /** @return a function copying a Path to a given directory */
   def copyTo(dir: Path)(implicit sc: ScoobiConfiguration): Path => Boolean = (f: Path) =>
-    FileUtil.copy(fileSystem, f, fileSystem, dir, false, sc)
+    FileUtil.copy(fileSystem, f, FileSystem.get(dir.toUri, sc.configuration), dir, false, sc)
 
   /** @return the path with a trailing slash */
   def dirPath(s: String) = if (s endsWith "/") s else s+"/"


### PR DESCRIPTION
Needs FileSystem.get in FileSystems.copyTo for use in mixed S3/HDFS. cf #185, #199. Fixes #239.
