### PR TITLE
Use an int instead of a double for shuffling key

### DIFF
--- a/src/main/scala/com/nicta/scoobi/core/DList.scala
+++ b/src/main/scala/com/nicta/scoobi/core/DList.scala
@@ -233,7 +233,7 @@ trait DList[A] extends DataSinks with Persistent[Seq[A]] {
   }
 
   /** Randomly suffle a DList. */
-  def shuffle: DList[A] = groupBy(_ => scala.util.Random.nextDouble()).mapFlatten(kvs => kvs._2)
+  def shuffle: DList[A] = groupBy(_ => util.Random.nextInt()).mapFlatten(_._2)
 
   /** Group the values of a distributed list according to some discriminator function. */
   def groupBy[K : WireFormat : Grouping](f: A => K): DList[(K, Iterable[A])] =


### PR DESCRIPTION
We decide the partition by calling .hashCode on the key, which
returns an Int. So generating anything larger than an Int is a
waste of space and computation (and calling .hashCode on an int is
much faster, as it merely returns the value as opposed to actually
doing any hashing)
