### PR TITLE
Change all nicta.github.com links to github.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Scoobi is a library that leverages the Scala programming language to provide a p
 
 ### Install
 
-See the [install instructions](http://nicta.github.com/scoobi/guide/Quick%20Start.html#Installing+Scoobi) in the QuickStart section of the [User Guide](http://nicta.github.com/scoobi/guide/User%20Guide.html).
+See the [install instructions](http://nicta.github.io/scoobi/guide/Quick%20Start.html#Installing+Scoobi) in the QuickStart section of the [User Guide](http://nicta.github.io/scoobi/guide/User%20Guide.html).
 
 ### Features
 
@@ -29,9 +29,9 @@ See the [install instructions](http://nicta.github.com/scoobi/guide/Quick%20Star
  * Strong typing - the APIs are strongly typed so as to catch more errors at compile time, a
  major improvement over standard Hadoop MapReduce where type-based run-time errors often occur
 
- * Ability to parameterise with rich [data types](http://nicta.github.com/scoobi/guide/Data%20Types.html) - unlike Hadoop MapReduce, which requires that you go off implementing a myriad of classes that implement the `Writable` interface, Scoobi allows `DList` objects to be parameterised by normal Scala types including value types (e.g. `Int`, `String`, `Double`), tuple types (with arbitrary nesting) as well as **case classes**
+ * Ability to parameterise with rich [data types](http://nicta.github.io/scoobi/guide/Data%20Types.html) - unlike Hadoop MapReduce, which requires that you go off implementing a myriad of classes that implement the `Writable` interface, Scoobi allows `DList` objects to be parameterised by normal Scala types including value types (e.g. `Int`, `String`, `Double`), tuple types (with arbitrary nesting) as well as **case classes**
 
- * Support for multiple types of I/O - currently built-in support for [text](http://nicta.github.com/scoobi/guide/Input%20and%20Output.html#Text+files), [Sequence](http://nicta.github.com/scoobi/guide/Input%20and%20Output.html#Sequence+files) and [Avro](http://nicta.github.com/scoobi/guide/Input%20and%20Output.html#Avro+files) files with the ability to implement support for [custom sources/sinks](http://nicta.github.com/scoobi/guide/Input%20and%20Output.html#Custom+sources+and+sinks)
+ * Support for multiple types of I/O - currently built-in support for [text](http://nicta.github.io/scoobi/guide/Input%20and%20Output.html#Text+files), [Sequence](http://nicta.github.io/scoobi/guide/Input%20and%20Output.html#Sequence+files) and [Avro](http://nicta.github.io/scoobi/guide/Input%20and%20Output.html#Avro+files) files with the ability to implement support for [custom sources/sinks](http://nicta.github.io/scoobi/guide/Input%20and%20Output.html#Custom+sources+and+sinks)
 
  * Optimization across library boundaries - the optimiser and execution engine will assemble Scoobi code spread across multiple software components so you still keep the benefits of modularity
 
@@ -41,7 +41,7 @@ See the [install instructions](http://nicta.github.com/scoobi/guide/Quick%20Star
 
 ### Getting Started
 
-To get started, read the [getting started steps](http://nicta.github.com/scoobi/guide/Quick%20Start.html) and the section on [distributed lists](http://nicta.github.com/scoobi/guide/Distributed%20Lists.html). The remaining sections in the [User Guide](http://nicta.github.com/scoobi/guide/User%20Guide.html) provide further detail on various aspects of Scoobi's functionality.
+To get started, read the [getting started steps](http://nicta.github.io/scoobi/guide/Quick%20Start.html) and the section on [distributed lists](http://nicta.github.io/scoobi/guide/Distributed%20Lists.html). The remaining sections in the [User Guide](http://nicta.github.io/scoobi/guide/User%20Guide.html) provide further detail on various aspects of Scoobi's functionality.
 
 The user mailing list is at <http://groups.google.com/group/scoobi-users>. Please use it for questions and comments!
 
@@ -50,9 +50,9 @@ The user mailing list is at <http://groups.google.com/group/scoobi-users>. Pleas
  * [Issues](https://github.com/NICTA/scoobi/issues)
  * [Change history](http://notes.implicit.ly/tagged/scoobi)
  * [Source code (github)](https://github.com/NICTA/scoobi)
- * [API Documentation](http://nicta.github.com/scoobi/api/SCOOBI-0.6.0-cdh4/index.html)
+ * [API Documentation](http://nicta.github.io/scoobi/api/SCOOBI-0.6.0-cdh4/index.html)
  * [Examples](https://github.com/NICTA/scoobi/tree/SCOOBI-0.6.0-cdh4/examples)
- * User Guide for the [SNAPSHOT](http://nicta.github.com/scoobi/guide-SNAPSHOT/guide/User%20Guide.html) version ([latest api](http://nicta.github.com/scoobi/api/master/scala/index.html))
+ * User Guide for the [SNAPSHOT](http://nicta.github.io/scoobi/guide-SNAPSHOT/guide/User%20Guide.html) version ([latest api](http://nicta.github.io/scoobi/api/master/scala/index.html))
  * Mailing Lists: [scoobi-users](http://groups.google.com/group/scoobi-users), [scoobi-dev](http://groups.google.com/group/scoobi-dev)
   
                        

--- a/examples/avro/build.sbt
+++ b/examples/avro/build.sbt
@@ -8,7 +8,7 @@ scalaVersion := "2.10.1"
 
 scalacOptions ++= Seq("-deprecation")
 
-resolvers ++= Seq("nicta" at "http://nicta.github.com/scoobi/releases",
+resolvers ++= Seq("nicta" at "http://nicta.github.io/scoobi/releases",
                   "sonatype snapshots" at "http://oss.sonatype.org/content/repositories/snapshots",
                   "cloudera" at "https://repository.cloudera.com/content/repositories/releases",
                   "Radlab Repository" at "http://scads.knowsql.org/nexus/content/groups/public/")

--- a/examples/fatjar/build.sbt
+++ b/examples/fatjar/build.sbt
@@ -13,7 +13,7 @@ scalacOptions ++= Seq("-deprecation")
 
 libraryDependencies ++= Seq("com.nicta" %% "scoobi" % "0.7.0-cdh4-SNAPSHOT")
 
-resolvers ++= Seq("nicta" at "http://nicta.github.com/scoobi/releases",
+resolvers ++= Seq("nicta" at "http://nicta.github.io/scoobi/releases",
                   "sonatype snapshots" at "http://oss.sonatype.org/content/repositories/snapshots",
                   "cloudera" at "https://repository.cloudera.com/content/repositories/releases",
                   "apache"   at "https://repository.apache.org/content/repositories/releases")

--- a/examples/pageRank/build.sbt
+++ b/examples/pageRank/build.sbt
@@ -9,6 +9,6 @@ libraryDependencies ++=
 
 scalacOptions ++= Seq("-deprecation")
 
-resolvers ++= Seq("nicta" at "http://nicta.github.com/scoobi/releases",
+resolvers ++= Seq("nicta" at "http://nicta.github.io/scoobi/releases",
                   "sonatype snapshots" at "http://oss.sonatype.org/content/repositories/snapshots",
                   "cloudera" at "https://repository.cloudera.com/content/repositories/releases")

--- a/examples/scoobding/build.sbt
+++ b/examples/scoobding/build.sbt
@@ -14,6 +14,6 @@ libraryDependencies ++=
       "cc.co.scala-reactive" %% "reactive-core" % "0.3.0") 
 
 
-resolvers ++= Seq("nicta" at "http://nicta.github.com/scoobi/releases",
+resolvers ++= Seq("nicta" at "http://nicta.github.io/scoobi/releases",
                   "sonatype snapshots" at "http://oss.sonatype.org/content/repositories/snapshots",
                   "cloudera" at "https://repository.cloudera.com/content/repositories/releases")

--- a/examples/wordCount/build.sbt
+++ b/examples/wordCount/build.sbt
@@ -8,7 +8,7 @@ scalacOptions ++= Seq("-deprecation")
 
 libraryDependencies ++= Seq("com.nicta" %% "scoobi" % "0.7.0-cdh4-SNAPSHOT")
 
-resolvers ++= Seq("nicta" at "http://nicta.github.com/scoobi/releases",
+resolvers ++= Seq("nicta" at "http://nicta.github.io/scoobi/releases",
                   "sonatype releases" at "http://oss.sonatype.org/content/repositories/releases",
                   "sonatype snapshots" at "http://oss.sonatype.org/content/repositories/snapshots",
                   "cloudera" at "https://repository.cloudera.com/content/repositories/releases")

--- a/pom.xml
+++ b/pom.xml
@@ -147,7 +147,7 @@
         <repository>
             <id>nictasavro</id>
             <name>nictasavro</name>
-            <url>http://nicta.github.com/scoobi/releases/</url>
+            <url>http://nicta.github.io/scoobi/releases/</url>
             <layout>default</layout>
         </repository>
         <repository>

--- a/project/build.scala
+++ b/project/build.scala
@@ -91,7 +91,7 @@ object build extends Build {
       "org.apache.commons"                %  "commons-math"              % "2.2"              % "test",
       "org.apache.commons"                %  "commons-compress"          % "1.0"              % "test"
     ) ++ hadoop },
-    resolvers ++= Seq("nicta" at "http://nicta.github.com/scoobi/releases",
+    resolvers ++= Seq("nicta" at "http://nicta.github.io/scoobi/releases",
       "cloudera" at "https://repository.cloudera.com/content/repositories/releases",
       "sonatype-releases" at "http://oss.sonatype.org/content/repositories/releases",
       "sonatype-snapshots" at "http://oss.sonatype.org/content/repositories/snapshots")
@@ -141,7 +141,7 @@ object build extends Build {
     publishArtifact in Test := false,
     pomIncludeRepository := { x => false },
     pomExtra := (
-      <url>http://nicta.github.com/scoobi</url>
+      <url>http://nicta.github.io/scoobi</url>
       <licenses>
         <license>
           <name>Apache 2.0</name>

--- a/src/test/scala/com/nicta/scoobi/guide/Deployment.scala
+++ b/src/test/scala/com/nicta/scoobi/guide/Deployment.scala
@@ -113,7 +113,7 @@ libraryDependencies ++= Seq(
    "com.thoughtworks.xstream" % "xstream" % "1.4.3" intransitive()
    )
 
-resolvers ++= Seq("nicta's avro" at "http://nicta.github.com/scoobi/releases",
+resolvers ++= Seq("nicta's avro" at "http://nicta.github.io/scoobi/releases",
                   "sonatype snapshots" at "http://oss.sonatype.org/content/repositories/snapshots",
                   "cloudera" at "https://repository.cloudera.com/content/repositories/releases")
 ```

--- a/src/test/scala/com/nicta/scoobi/guide/QuickStart.scala
+++ b/src/test/scala/com/nicta/scoobi/guide/QuickStart.scala
@@ -51,7 +51,7 @@ libraryDependencies += "com.nicta" %% "scoobi" % "$VERSION"
 scalacOptions ++= Seq("-Ydependent-method-types", "-deprecation")
 
 resolvers ++= Seq(
-    "nicta's avro" at "http://nicta.github.com/scoobi/releases",
+    "nicta's avro" at "http://nicta.github.io/scoobi/releases",
     "cloudera" at "https://repository.cloudera.com/content/repositories/releases",
     "Sonatype-snapshots" at "http://oss.sonatype.org/content/repositories/snapshots")
 ```

--- a/src/test/scala/com/nicta/scoobi/guide/ScoobiVariables.scala
+++ b/src/test/scala/com/nicta/scoobi/guide/ScoobiVariables.scala
@@ -33,7 +33,7 @@ trait ScoobiVariables {
 
   lazy val BRANCH = if (IS_SNAPSHOT) "master" else PREVIOUS_VERSION_IF_SNAPSHOT
 
-  lazy val LANDING_PAGE = "http://nicta.github.com/scoobi/"
+  lazy val LANDING_PAGE = "http://nicta.github.io/scoobi/"
 
   lazy val API_DIR            = LANDING_PAGE+"api/"
   lazy val API_OFFICIAL_PAGE  = API_DIR+PREVIOUS_VERSION_IF_SNAPSHOT+"/index.html"


### PR DESCRIPTION
GitHub has changed all `gh-pages` links to live under `github.io`, which breaks the links to the scoobi maven repository. (There's a redirect, but sbt doesn't seem to follow it?)

Anyways, this commit replaces most references to `nicta.github.com` with `nicta.github.io`.
