### PR TITLE
Remove nicta repository from examples

### DIFF
--- a/examples/avro/build.sbt
+++ b/examples/avro/build.sbt
@@ -8,8 +8,7 @@ scalaVersion := "2.10.1"
 
 scalacOptions ++= Seq("-deprecation")
 
-resolvers ++= Seq("nicta" at "http://nicta.github.io/scoobi/releases",
-                  "sonatype snapshots" at "http://oss.sonatype.org/content/repositories/snapshots",
+resolvers ++= Seq("sonatype snapshots" at "http://oss.sonatype.org/content/repositories/snapshots",
                   "cloudera" at "https://repository.cloudera.com/content/repositories/releases",
                   "Radlab Repository" at "http://scads.knowsql.org/nexus/content/groups/public/")
 

--- a/examples/fatjar/build.sbt
+++ b/examples/fatjar/build.sbt
@@ -13,8 +13,7 @@ scalacOptions ++= Seq("-deprecation")
 
 libraryDependencies ++= Seq("com.nicta" %% "scoobi" % "0.7.0-cdh4-SNAPSHOT")
 
-resolvers ++= Seq("nicta" at "http://nicta.github.io/scoobi/releases",
-                  "sonatype snapshots" at "http://oss.sonatype.org/content/repositories/snapshots",
+resolvers ++= Seq("sonatype snapshots" at "http://oss.sonatype.org/content/repositories/snapshots",
                   "cloudera" at "https://repository.cloudera.com/content/repositories/releases",
                   "apache"   at "https://repository.apache.org/content/repositories/releases")
 

--- a/examples/pageRank/build.sbt
+++ b/examples/pageRank/build.sbt
@@ -9,6 +9,5 @@ libraryDependencies ++=
 
 scalacOptions ++= Seq("-deprecation")
 
-resolvers ++= Seq("nicta" at "http://nicta.github.io/scoobi/releases",
-                  "sonatype snapshots" at "http://oss.sonatype.org/content/repositories/snapshots",
+resolvers ++= Seq("sonatype snapshots" at "http://oss.sonatype.org/content/repositories/snapshots",
                   "cloudera" at "https://repository.cloudera.com/content/repositories/releases")

--- a/examples/scoobding/build.sbt
+++ b/examples/scoobding/build.sbt
@@ -14,6 +14,5 @@ libraryDependencies ++=
       "cc.co.scala-reactive" %% "reactive-core" % "0.3.0") 
 
 
-resolvers ++= Seq("nicta" at "http://nicta.github.io/scoobi/releases",
-                  "sonatype snapshots" at "http://oss.sonatype.org/content/repositories/snapshots",
+resolvers ++= Seq("sonatype snapshots" at "http://oss.sonatype.org/content/repositories/snapshots",
                   "cloudera" at "https://repository.cloudera.com/content/repositories/releases")

--- a/examples/wordCount/build.sbt
+++ b/examples/wordCount/build.sbt
@@ -8,7 +8,6 @@ scalacOptions ++= Seq("-deprecation")
 
 libraryDependencies ++= Seq("com.nicta" %% "scoobi" % "0.7.0-cdh4-SNAPSHOT")
 
-resolvers ++= Seq("nicta" at "http://nicta.github.io/scoobi/releases",
-                  "sonatype releases" at "http://oss.sonatype.org/content/repositories/releases",
+resolvers ++= Seq("sonatype releases" at "http://oss.sonatype.org/content/repositories/releases",
                   "sonatype snapshots" at "http://oss.sonatype.org/content/repositories/snapshots",
                   "cloudera" at "https://repository.cloudera.com/content/repositories/releases")


### PR DESCRIPTION
There's something a bit screwy with this repository
that on a fresh machine causes errors like:

[warn] [NOT FOUND ] org.apache.avro#avro;1.5.4!avro.jar

but the errors disappear after you have a properly downloaded it
