### PR TITLE
Experimental diff

### DIFF
--- a/src/test/scala/com/nicta/scoobi/core/DListSpec.scala
+++ b/src/test/scala/com/nicta/scoobi/core/DListSpec.scala
@@ -125,12 +125,22 @@ class DListSpec extends NictaSimpleJobs with TerminationMatchers with ScalaCheck
     run((a isEqual a, a isEqual b, b isEqual a, a1 isEqual a)) must_== (true, true, true, false)
   }
 
-  "A shuffled DList doesn't contain any more or less elements" >> { implicit sc: SC =>
+  "A shuffled DList contains the same elements" >> { implicit sc: SC =>
     val shuffleProp = (list: List[Int]) => {
       val orig = list.toDList
       run(orig.shuffle isEqual orig) must_== true
     }
     Prop.forAll(shuffleProp).set(minTestsOk = 5, minSize = 0, maxSize = 100000)
+  }
+
+  "DList diff'ing actually works works" >> { implicit sc: SC =>
+    
+    val eqProp = (first: List[Int], second: List[Int]) => {
+      run(first.toDList diff second.toDList) must_== (first diff second)
+      run(first.toDList distinctDiff second.toDList) must_== (first.toSet diff second.toSet).toList
+    }
+    
+    Prop.forAll(eqProp).set(minTestsOk = 5, minSize = 0, maxSize = 100000)
   }
 }
 


### PR DESCRIPTION
distinctDiff is arguably a lot more useful (and really what I actually needed) but I implemented .diff too, just for consistency with Scala's Iterables.

P.S. I think the unit tests thing is broken, as it looks to be running the test an infinite amount of times

and scoobi verbose is a bit too verbose, it's dumping the actual data in the DList which is a bit .. :/
