### PR TITLE
Make DList.partition work with nonepure funcs

### DIFF
--- a/src/main/scala/com/nicta/scoobi/core/DList.scala
+++ b/src/main/scala/com/nicta/scoobi/core/DList.scala
@@ -126,7 +126,10 @@ trait DList[A] extends DataSinks with Persistent[Seq[A]] {
   /**Partitions this distributed list into a pair of distributed lists according to some
    * predicate. The first distributed list consists of elements that satisfy the predicate
    * and the second of all elements that don't. */
-  def partition(p: A => Boolean): (DList[A], DList[A]) = (filter(p), filterNot(p))
+  def partition(p: A => Boolean): (DList[A], DList[A]) = {
+    val t = map(x => (x, p(x)))
+    (t.filter(_._2).map(_._1), t.filterNot(_._2).map(_._1))
+  }
 
   /**Converts a distributed list of iterable values into to a distributed list in which
    * all the values are concatenated. */

--- a/src/test/scala/com/nicta/scoobi/core/DListSpec.scala
+++ b/src/test/scala/com/nicta/scoobi/core/DListSpec.scala
@@ -157,6 +157,14 @@ class DListSpec extends NictaSimpleJobs with TerminationMatchers with ScalaCheck
     
     Prop.forAllNoShrink(arbitrary[List[Int]], arbitrary[List[Int]])(eqProp).set(minTestsOk = 5, minSize = 0, maxSize = 10)
   }
+  
+  "DList partition works" >> { implicit sc: SC =>
+    val shuffleProp = (list: List[Int]) => {
+      val (l, r) = list.toDList.partition(_ => util.Random.nextBoolean)
+      (run(l) ++ run(r)).sorted.toList must_== list.sorted
+    }
+    Prop.forAllNoShrink(arbitrary[List[Int]])(shuffleProp).set(minTestsOk = 5, minSize = 0, maxSize = 100)
+  }
 }
 
 case class PoorHashString(s: String) {


### PR DESCRIPTION
DList.partition should only call the function once per element in the DList. This is very important for predicting performance (e.g. the function is super duper expensive) and even more importantly, when using a non-pure function. For instance, if you used partition to split your data into two parts based on a random number generator -- with the current code, you would have duplicates (and missing elements) in the final results. This is extremely unexpected.

This unit test fails (for which, I'll create a bug), but the pull request introduces no regressions   per se so I think its safe to pull.
