### PR TITLE
Add stratify methods to DList.

### DIFF
--- a/src/test/scala/com/nicta/scoobi/core/DListSpec.scala
+++ b/src/test/scala/com/nicta/scoobi/core/DListSpec.scala
@@ -22,8 +22,8 @@ import testing.mutable.NictaSimpleJobs
 import Scoobi._
 import org.specs2.matcher.TerminationMatchers
 import org.specs2.ScalaCheck
-import org.scalacheck.Prop
 import impl.plan.comp.CompNodeData._
+import org.scalacheck._
 import org.scalacheck.Arbitrary._
 
 class DListSpec extends NictaSimpleJobs with TerminationMatchers with ScalaCheck {
@@ -112,24 +112,24 @@ class DListSpec extends NictaSimpleJobs with TerminationMatchers with ScalaCheck
     uniqueIndexes === len
     maxIndex      === (len - 1)
   }
-  
+
   "DList distinct works" >> { implicit sc: SC =>
     implicit def fmt = mkCaseWireFormat(PoorHashString, PoorHashString.unapply _)
-    
-    val words = (1 to 1000).map { x => PoorHashString(util.Random.nextString(1)) }
-    
+
+    val words = (1 to 1000).map { x => PoorHashString(scala.util.Random.nextString(1)) }
+
     words.toDList.distinct.size.run must_== words.distinct.size
   }
 
   "DList isEqual works" >> { implicit sc: SC =>
-    
+
     val as = (1 to 100).map(scala.util.Random.nextInt(_).toString) // lots of dupes
     val bs = scala.util.Random.shuffle(as)
-    
+
     val a = as.toDList
     val b = bs.toDList
     val a1 = a.filter(_ != bs.head)
-    
+
     run((a isEqual a, a isEqual b, b isEqual a, a1 isEqual a)) must_== (true, true, true, false)
   }
 
@@ -151,29 +151,59 @@ class DListSpec extends NictaSimpleJobs with TerminationMatchers with ScalaCheck
     list.run.normalise === "Vector(1, 2, 3)"
     "effect is evaluated" ==> { out.toString must not be empty }.unless(sc.isRemote)
   }
-  
+
   "DList diff'ing actually works works" >> { implicit sc: SC =>
-    
+
     val eqProp = (first: List[Int], second: List[Int]) => {
       run(first.toDList diff second.toDList).sorted must_== (first diff second).sorted
       run(first.toDList distinctDiff second.toDList).sorted must_== (first.toSet diff second.toSet).toList.sorted
     }
-    
+
     Prop.forAllNoShrink(arbitrary[List[Int]], arbitrary[List[Int]])(eqProp).set(minTestsOk = 5, minSize = 0, maxSize = 10)
   }
-  
-  "DList partition works" >> { implicit sc: SC =>
-    val shuffleProp = (list: List[Int]) => {
-      val (l, r) = list.toDList.partition(_ => util.Random.nextBoolean)
-      persist(l, r)
-      (l.run ++ r.run).sorted.toList must_== list.sorted
-    }
-    Prop.forAllNoShrink(arbitrary[List[Int]])(shuffleProp).set(minTestsOk = 5, minSize = 0, maxSize = 100)
-  }
 
+  "Partitioning a DList doesn't add or remove any elements" >> {
+
+    /**
+     * Property than when a DList is split into 1 or more, partitions, the concatenation of
+     * all partitions contains the same set of elements as the original DList.
+     */
+    def partitionProperty(f: DList[Int] => Seq[DList[Int]])(implicit sc: ScoobiConfiguration): List[Int] => Prop = {
+      (list: List[Int]) => {
+        (list.length > 0) ==>  {
+          val orig = list.toDList
+          val partitions = f(orig)
+          run(orig isEqual partitions.reduce(_ ++ _)) == true
+        }
+      }
+    }
+
+    def check(p: Prop) = p.set(minTestsOk = 5, minSize = 0, maxSize = 100000)
+
+    "Into 2 DLists" >> { implicit sc: SC =>
+      val prop = partitionProperty { xs =>
+        val (l, r) = xs.partition(_ => scala.util.Random.nextBoolean())
+        Seq(l, r)
+      }
+      check { Prop.forAllNoShrink(arbitrary[List[Int]])(prop) }
+    }
+
+    "Stratifying" >> { sc: SC =>
+      val prop = (n: Int, list: List[Int]) => partitionProperty(_.stratify(n)(i => math.abs(i % n)))(sc)(list)
+      check { Prop.forAllNoShrink(Gen.choose(1, 10), arbitrary[List[Int]])(prop) }
+    }
+
+    "Stratifying with weights" >> { sc: SC =>
+      def genWeights: Gen[Seq[Int]] = for {
+        n  <- Gen.choose(1, 10)
+        ws <- Gen.containerOfN[List, Int](n, Gen.choose(1, 30))
+      } yield ws.toSeq
+      val prop = (ws: Seq[Int], list: List[Int]) => partitionProperty(_.stratifyWeighted(ws))(sc)(list)
+      check { Prop.forAllNoShrink(genWeights, arbitrary[List[Int]])(prop) }
+    }
+  }
 }
 
 case class PoorHashString(s: String) {
   override def hashCode() = s.hashCode() & 0xff
 }
-


### PR DESCRIPTION
Implement 'stratify' and 'stratifyWeighted' on DList. 'stratify' is a
generalised version of 'partition'. Add specs that leverage ScalaCheck
to vary the generated DLists as well as the number and relative sizes of
stratums/partitions.

Added specs pass in in-memory and local mode. Haven't been able to test cluster mode.

@etorreborre - helpful if we can include in 0.7. 
