### PR TITLE
Issue #303: Updated hadoop-* dependency versions for -hadoop2 to 2.2.0

### DIFF
--- a/project/dependencies.scala
+++ b/project/dependencies.scala
@@ -45,7 +45,7 @@ object dependencies {
                                          "org.apache.hadoop" % "hadoop-mapreduce-client-jobclient" % "2.2.0",
                                          "org.apache.hadoop" % "hadoop-mapreduce-client-core"      % "2.2.0",
                                          "org.apache.hadoop" % "hadoop-annotations"                % "2.2.0",
-                                         "org.apache.avro"   % "avro-mapred"                       % "1.7.4")
+                                         "org.apache.avro"   % "avro-mapred"                       % "1.7.4" classifier "hadoop2")
     else if (version.contains("cdh3")) Seq("org.apache.hadoop" % "hadoop-core"   % "0.20.2-cdh3u1",
                                            "org.apache.avro"   % "avro-mapred"   % "1.7.4")
     else                          Seq("org.apache.hadoop" % "hadoop-client" % "2.0.0-mr1-cdh4.0.1" exclude("asm", "asm"),


### PR DESCRIPTION
In order to get the Scoobi WordCount example working on a CDH5-beta1 cluster,
I've changed the hadoop-\* dependency versions from 2.1.0.2.0.5.0-67 to 2.2.0
and removed the dependency on the hortonworks repository at the same time.

WARNING: I have no idea how this will affect Hadoop distributions based on APIs released before 2.2.0, e.g. CDH4. (See Issue #300) However, 2.2.0 is the first GA release of Hadoop 2, so I guess there needs to be a decision whether you want to support pre-GA releases going forward. Over to you guys... :)
