### PR TITLE
Moved partition sink setup to outputConfigure so it gets executed on the client and not each mapper.

### DIFF
--- a/src/main/scala/com/nicta/scoobi/io/text/TextFilePartitionedSink.scala
+++ b/src/main/scala/com/nicta/scoobi/io/text/TextFilePartitionedSink.scala
@@ -51,11 +51,8 @@ case class TextFilePartitionedSink[K : Manifest, V : Manifest](
   }
 
   def outputPath(implicit sc: ScoobiConfiguration) = Some(output)
-  def outputConfigure(job: Job)(implicit sc: ScoobiConfiguration) {}
 
-  override def outputSetup(implicit sc: ScoobiConfiguration) {
-    super.outputSetup(sc)
-
+  def outputConfigure(job: Job)(implicit sc: ScoobiConfiguration) {
     if (Files.pathExists(output)(sc.configuration) && overwrite) {
       logger.info("Deleting the pre-existing output path: " + output.toUri.toASCIIString)
       Files.deletePath(output)(sc.configuration)


### PR DESCRIPTION
This fixes the org.apache.hadoop.hdfs.server.namenode.LeaseExpiredException when using textFilePartitionedSink and multiple mappers
