### PR TITLE
Remove unused type param for persistent

### DIFF
--- a/src/main/scala/com/nicta/scoobi/application/Persist.scala
+++ b/src/main/scala/com/nicta/scoobi/application/Persist.scala
@@ -31,7 +31,7 @@ trait Persist { outer =>
   /** Persisting */
   def persist[A](o: DObject[A])(implicit sc: core.ScoobiConfiguration) =     { sc.persist(o) }
   def persist[A](list: core.DList[A])(implicit sc: core.ScoobiConfiguration) = { sc.persist(list) }
-  def persist[A](ps: Persistent[_]*)(implicit sc: core.ScoobiConfiguration)  = { sc.persist(ps) }
+  def persist(ps: Persistent[_]*)(implicit sc: core.ScoobiConfiguration)  = { sc.persist(ps) }
 
   /**
    * run a list.

--- a/src/main/scala/com/nicta/scoobi/core/ScoobiConfiguration.scala
+++ b/src/main/scala/com/nicta/scoobi/core/ScoobiConfiguration.scala
@@ -96,7 +96,7 @@ trait ScoobiConfiguration {
   def fileSystem: FileSystem
   def newEnv(wf: WireReaderWriter): Environment
 
-  def persist[A](ps: Seq[Persistent[_]]): Seq[Persistent[_]]
+  def persist(ps: Seq[Persistent[_]]): Seq[Persistent[_]]
   def persist[A](list: DList[A]): DList[A]
   def persist[A](o: DObject[A]): A
   def duplicate: ScoobiConfiguration

--- a/src/main/scala/com/nicta/scoobi/impl/ScoobiConfigurationImpl.scala
+++ b/src/main/scala/com/nicta/scoobi/impl/ScoobiConfigurationImpl.scala
@@ -386,7 +386,7 @@ case class ScoobiConfigurationImpl(private val hadoopConfiguration: Configuratio
 
   private val persister = new Persister(this)
 
-  def persist[A](ps: Seq[Persistent[_]]) = persister.persist(ps)
+  def persist(ps: Seq[Persistent[_]])    = persister.persist(ps)
   def persist[A](list: DList[A])         = persister.persist(list)
   def persist[A](o: DObject[A]): A       = persister.persist(o)
 


### PR DESCRIPTION
I'm not sure this actually does anything to work around the scalac bug (https://issues.scala-lang.org/browse/SI-8757).
