### PR TITLE
Changing the DoubleWireformat class output string to "Double" from "Float"

### DIFF
--- a/src/main/scala/com/nicta/scoobi/core/WireFormat.scala
+++ b/src/main/scala/com/nicta/scoobi/core/WireFormat.scala
@@ -340,7 +340,7 @@ trait WireFormatImplicits extends codegen.GeneratedWireFormats {
   class DoubleWireFormat extends WireFormat[Double] {
     def toWire(x: Double, out: DataOutput) { out.writeDouble(x) }
     def fromWire(in: DataInput): Double = { in.readDouble() }
-    override def toString = "Float"
+    override def toString = "Double"
   }
 
   implicit def FloatFmt = new FloatWireFormat


### PR DESCRIPTION
Having "Float" in the logs even for "Double" values is misleading and confusing. So differentiating the output string of the double values from the floats. 
