### PR TITLE
Fix for NullPointerException while updating hadoop job counters.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,4 @@ scala:
 jdk:
   - oraclejdk7
  
--script: sbt 'test-only -- -include hadoop -exclude unstable '
+script: sbt clean compile package

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,4 @@ scala:
 jdk:
   - oraclejdk7
  
-script: sbt clean package
+script: sbt clean test package

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,4 @@ scala:
 jdk:
   - oraclejdk7
  
-script: sbt clean compile package
+-script: sbt 'test-only -- -include hadoop -exclude unstable '

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,4 @@ scala:
 jdk:
   - oraclejdk7
  
-script: sbt 'clean compile package -- -include hadoop -exclude unstable '
+script: sbt 'clean compile package'

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,4 @@ scala:
 jdk:
   - oraclejdk7
  
-script: sbt clean test package
+script: sbt clean compile package

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,4 @@ scala:
 jdk:
   - oraclejdk7
  
-script: sbt clean compile package
+script: sbt clean package

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,5 @@ scala:
 
 jdk:
   - oraclejdk7
-
+ 
 script: sbt 'test-only -- -include hadoop -exclude unstable '

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,4 @@ scala:
 jdk:
   - oraclejdk7
  
-script: sbt 'test-only -- -include hadoop -exclude unstable '
+script: sbt 'clean compile package -- -include hadoop -exclude unstable '

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,4 @@ scala:
 jdk:
   - oraclejdk7
  
-script: sbt 'clean compile package'
+script: sbt clean compile package

--- a/src/main/scala/com/nicta/scoobi/impl/ScoobiConfigurationImpl.scala
+++ b/src/main/scala/com/nicta/scoobi/impl/ScoobiConfigurationImpl.scala
@@ -105,9 +105,14 @@ case class ScoobiConfigurationImpl(private val hadoopConfiguration: Configuratio
 
   /** update the current counters from the result of a job that has just been run */
   def updateCounters(hadoopCounters: HadoopCounters) = {
-    hadoopCounters.getGroupNames.map { groupName: String =>
-           val group = hadoopCounters.getGroup(groupName)
-           group.iterator.foreach((c: Counter) => counters.findCounter(groupName, c.getName).increment(c.getValue))
+    val groupNames = Option(hadoopCounters.getGroupNames)
+    if(groupNames.isDefined) {
+        groupNames.get.map { groupName: String =>
+           val group = Option(hadoopCounters.getGroup(groupName))
+           if(group.isDefined) {
+             group.get.iterator.foreach((c: Counter) => counters.findCounter(groupName, c.getName).increment(c.getValue))
+           }
+        }
     }
     this
   }

--- a/src/main/scala/com/nicta/scoobi/impl/ScoobiConfigurationImpl.scala
+++ b/src/main/scala/com/nicta/scoobi/impl/ScoobiConfigurationImpl.scala
@@ -108,10 +108,8 @@ case class ScoobiConfigurationImpl(private val hadoopConfiguration: Configuratio
     val groupNames = Option(hadoopCounters.getGroupNames)                                     
     if(groupNames.isDefined) {
         groupNames.map { groupName: String =>
-           val group = Option(hadoopCounters.getGroup(groupName))
-           if(group.isDefined) {
-             group.iterator.foreach((c: Counter) => counters.findCounter(groupName, c.getName).increment(c.getValue))
-           }
+           val group = hadoopCounters.getGroup(groupName)
+           group.iterator.foreach((c: Counter) => counters.findCounter(groupName, c.getName).increment(c.getValue))
         }
     }
     this

--- a/src/main/scala/com/nicta/scoobi/impl/ScoobiConfigurationImpl.scala
+++ b/src/main/scala/com/nicta/scoobi/impl/ScoobiConfigurationImpl.scala
@@ -105,12 +105,9 @@ case class ScoobiConfigurationImpl(private val hadoopConfiguration: Configuratio
 
   /** update the current counters from the result of a job that has just been run */
   def updateCounters(hadoopCounters: HadoopCounters) = {
-    val groupNames = Option(hadoopCounters.getGroupNames)                                     
-    if(groupNames.isDefined) {
-        groupNames.map { groupName: String =>
+    hadoopCounters.getGroupNames.map { groupName: String =>
            val group = hadoopCounters.getGroup(groupName)
            group.iterator.foreach((c: Counter) => counters.findCounter(groupName, c.getName).increment(c.getValue))
-        }
     }
     this
   }

--- a/src/main/scala/com/nicta/scoobi/impl/ScoobiConfigurationImpl.scala
+++ b/src/main/scala/com/nicta/scoobi/impl/ScoobiConfigurationImpl.scala
@@ -105,9 +105,14 @@ case class ScoobiConfigurationImpl(private val hadoopConfiguration: Configuratio
 
   /** update the current counters from the result of a job that has just been run */
   def updateCounters(hadoopCounters: HadoopCounters) = {
-    hadoopCounters.getGroupNames.map { groupName: String =>
-      val group = hadoopCounters.getGroup(groupName)
-      group.iterator.foreach((c: Counter) => counters.findCounter(groupName, c.getName).increment(c.getValue))
+    val groupNames = Option(hadoopCounters.getGroupNames)                                     
+    if(groupNames.isDefined) {
+        groupNames.map { groupName: String =>
+           val group = Option(hadoopCounters.getGroup(groupName))
+           if(group.isDefined) {
+             group.iterator.foreach((c: Counter) => counters.findCounter(groupName, c.getName).increment(c.getValue))
+           }
+        }
     }
     this
   }


### PR DESCRIPTION
1)
Error seen in scoobi Version: 0.8.3

We have seen this error repeatedly. Even if the job succeeded with few failed map attempts, scoobi threw null pointer exception. Hence adding null checks.
Logs
===
[INFO] OutputChannel - scoobi.tmp.copy : mrename
[INFO] OutputChannel - Rename Time : 1 mins
[INFO] OutputChannel - scoobi.tmp.copy : mrename
[INFO] OutputChannel - Rename Time : 0 mins
Exception in thread "main" java.lang.NullPointerException
	at com.nicta.scoobi.impl.ScoobiConfigurationImpl.updateCounters(ScoobiConfigurationImpl.scala:99)
	at com.nicta.scoobi.impl.ScoobiConfigurationImpl.updateCounters(ScoobiConfigurationImpl.scala:45)
	at com.nicta.scoobi.impl.exec.HadoopMode$Execution$$anonfun$reportMscr$1.apply(HadoopMode.scala:173)
	at com.nicta.scoobi.impl.exec.HadoopMode$Execution$$anonfun$reportMscr$1.apply(HadoopMode.scala:171)
	at scala.Function2$$anonfun$tupled$1.apply(Function2.scala:54)
	at scala.Function2$$anonfun$tupled$1.apply(Function2.scala:53)
	at scala.collection.TraversableLike$$anonfun$map$1.apply(TraversableLike.scala:244)
	at scala.collection.TraversableLike$$anonfun$map$1.apply(TraversableLike.scala:244)
	at scala.collection.immutable.List.foreach(List.scala:318)
	at scala.collection.TraversableLike$class.map(TraversableLike.scala:244)
	at scala.collection.AbstractTraversable.map(Traversable.scala:105)
	at com.nicta.scoobi.impl.exec.HadoopMode$Execution.runMscrs(HadoopMode.scala:146)
	at com.nicta.scoobi.impl.exec.HadoopMode$Execution.execute(HadoopMode.scala:125)
	at com.nicta.scoobi.impl.exec.HadoopMode$$anonfun$com$nicta$scoobi$impl$exec$HadoopMode$$executeLayer$1.apply(HadoopMode.scala:115)
	at com.nicta.scoobi.impl.exec.HadoopMode$$anonfun$com$nicta$scoobi$impl$exec$HadoopMode$$executeLayer$1.apply(HadoopMode.scala:114)
	at org.kiama.attribution.AttributionCore$CachedAttribute.apply(AttributionCore.scala:62)
	at com.nicta.scoobi.impl.exec.HadoopMode$$anonfun$com$nicta$scoobi$impl$exec$HadoopMode$$executeLayers$1$1.apply(HadoopMode.scala:73)
	at com.nicta.scoobi.impl.exec.HadoopMode$$anonfun$com$nicta$scoobi$impl$exec$HadoopMode$$executeLayers$1$1.apply(HadoopMode.scala:73)
	at scala.collection.immutable.List.foreach(List.scala:318)


Travis Build is Success = https://travis-ci.org/deepujain/scoobi

2) Updated .travis* file to include compilation and packaging.
