### PR TITLE
update xstream and scala library versions

### DIFF
--- a/project/build.scala
+++ b/project/build.scala
@@ -71,7 +71,7 @@ object build extends Build {
     name := "scoobi",
     organization := "com.nicta",
     scoobiVersion in GlobalScope <<= version,
-    scalaVersion := "2.11.2",
+    scalaVersion := "2.11.5",
     crossScalaVersions := Seq("2.10.4", scalaVersion.value),
     // https://gist.github.com/djspiewak/976cd8ac65e20e136f05
     unmanagedSourceDirectories in Compile += (sourceDirectory in Compile).value / s"scala-${scalaBinaryVersion.value}"

--- a/project/dependencies.scala
+++ b/project/dependencies.scala
@@ -30,7 +30,7 @@ object dependencies {
   def scoobi(scalaVersion: String) = Seq(
     "org.scala-lang"                    %  "scala-compiler"            % scalaVersion,
     "org.apache.avro"                   %  "avro"                      % "1.7.4",
-    "com.thoughtworks.xstream"          %  "xstream"                   % "1.4.4"            intransitive(),
+    "com.thoughtworks.xstream"          %  "xstream"                   % "1.4.8"            intransitive(),
     "javassist"                         %  "javassist"                 % "3.12.1.GA",
     "com.googlecode.kiama"              %% "kiama"                     % "1.6.0",
   if (scalaVersion.contains("2.10"))


### PR DESCRIPTION
the xstream fixes issues with running scoobi under java 1.8.0
the update in the scala library is just to bring it to current