### PR TITLE
Set replication for cache files

### DIFF
--- a/src/main/scala/com/nicta/scoobi/impl/util/DistCache.scala
+++ b/src/main/scala/com/nicta/scoobi/impl/util/DistCache.scala
@@ -75,6 +75,7 @@ object DistCache {
     try serialiser(obj, dos)
     finally dos.close
     cache.addCacheFile(path.toUri, configuration)
+    path.getFileSystem(configuration).setReplication(path, configuration.getInt("mapreduce.client.submit.file.replication", 10).toShort)
     path
   }
 


### PR DESCRIPTION
For big jobs with many maps and reduces, 3 replicates for Distribute cache is too small.